### PR TITLE
Room templates now only generated from allowed blueprints

### DIFF
--- a/Dungen.Tests.Render/Game1.cs
+++ b/Dungen.Tests.Render/Game1.cs
@@ -47,32 +47,6 @@ public class Game1 : Game
     }
 
     private DungenGraph InitializeDungeon() {
-        /*float x = 10/2;
-        float y = 10/2;
-
-        RoomBlueprint normal = new RoomBlueprint(
-            points: new List<Vector2F>(
-                new Vector2F[] {
-                    new Vector2F(x, y), 
-                    new Vector2F(x, -y),
-                    new Vector2F(-x, -y),
-                    new Vector2F(-x, y)}));
-
-        RoomDefinition normalDefinition = new RoomDefinition( 
-            blueprints: new List<RoomBlueprint>() { normal },
-            type: RoomType.Normal);
-
-        DungenGraph graph = new DungenGraph();
-
-        graph.AddRoom(0, normalDefinition);
-        graph.AddRoom(1, normalDefinition);
-        graph.AddRoom(2, normalDefinition);
-
-        graph.AddConnection(0, 1);
-        graph.AddConnection(1, 2);
-
-        return graph;*/
-
         float x = 50/2;
         float y = 30/2;
         
@@ -346,7 +320,7 @@ public class Game1 : Game
     void DrawRoom(Room room, Color color, int width = 1) {
         Vector2F pTmp = room.GetCenter();
         DrawString(
-            String.Format("{0} {1}", room.Number.ToString(), room.Type.ToString().Substring(0, 2)),
+            String.Format("{0}", room.Number.ToString()),
             new Vector2(pTmp.x, pTmp.y),
             0.8f);
 

--- a/Dungen.Tests/Unit.ConfigSpaces.cs
+++ b/Dungen.Tests/Unit.ConfigSpaces.cs
@@ -29,8 +29,8 @@ public class ConfigSpaces
     [Test]
     public void SpaceGeneratedFromShapes()
     {
-        Room fixedRoom = new Room(_hexL, RoomType.Normal);
-        Room movingRoom = new Room(_hexL, RoomType.Normal);
+        Room fixedRoom = new Room(_hexL);
+        Room movingRoom = new Room(_hexL);
 
         ConfigSpacesBuilder csBuilder = new ConfigSpacesBuilder();
 
@@ -44,14 +44,14 @@ public class ConfigSpaces
     {
         ConfigSpacesBuilder csBuilder = new ConfigSpacesBuilder();
 
-        Room fixedRoom = new Room(_hexL, RoomType.Normal);
-        Room movingRoom = new Room(_hexL, RoomType.Normal);
+        Room fixedRoom = new Room(_hexL);
+        Room movingRoom = new Room(_hexL);
 
         // Test too simplified as both shapes overlap so will intersect on every line
         // 
         // Note: Line's also intersect at the corners so we get 16 not the expected 8!
         //
-        Room fixedRoom2 = new Room(_hexL, RoomType.Normal);
+        Room fixedRoom2 = new Room(_hexL);
 
         csBuilder.TryFromRoom(fixedRoom, movingRoom, out ConfigSpace cspace1);
         csBuilder.TryFromRoom(fixedRoom2, movingRoom, out ConfigSpace cspace2);

--- a/Dungen.Tests/Unit.Geometry.cs
+++ b/Dungen.Tests/Unit.Geometry.cs
@@ -56,8 +56,8 @@ public class Layouts
     [Test]
     public void RoomDistance()
     {
-        Room room1 = new Room(_squareRoomBlueprint, RoomType.Normal);
-        Room room2 = new Room(_squareRoomBlueprint, RoomType.Normal);
+        Room room1 = new Room(_squareRoomBlueprint);
+        Room room2 = new Room(_squareRoomBlueprint);
         room2.Translate(new Vector2F(11, 11));
 
         Assert.That(
@@ -68,8 +68,8 @@ public class Layouts
     [Test]
     public void RoomCollisionArea()
     {
-        Room room1 = new Room(_squareRoomBlueprint, RoomType.Normal);
-        Room room2 = new Room(_squareRoomBlueprint, RoomType.Normal);
+        Room room1 = new Room(_squareRoomBlueprint);
+        Room room2 = new Room(_squareRoomBlueprint);
 
         room2.Translate(new Vector2F(2, 2));
 
@@ -88,8 +88,8 @@ public class Layouts
     [Test]
     public void RoomWallContactArea()
     {
-        Room room1 = new Room(_squareRoomBlueprint, RoomType.Normal);
-        Room room2 = new Room(_squareRoomBlueprint, RoomType.Normal);
+        Room room1 = new Room(_squareRoomBlueprint);
+        Room room2 = new Room(_squareRoomBlueprint);
 
         room2.Translate(new Vector2F(10, 5));
 
@@ -105,8 +105,8 @@ public class Layouts
 
         Layout layout = new Layout(new Layout(1), _graph);
 
-        Room r1 = new Room(_smallSquareRoomBlueprint, RoomType.Normal, 0);
-        Room r2 = new Room(_squareRoomBlueprint, RoomType.Normal, 1);
+        Room r1 = new Room(_smallSquareRoomBlueprint, 0);
+        Room r2 = new Room(_squareRoomBlueprint, 1);
 
         layout.Rooms.Add(vertices[0], r1);
         layout.Update(vertices[0], r1);
@@ -128,7 +128,7 @@ public class Layouts
     [Test]
     public void ScaleRoom()
     {
-        Room r1 = new Room(_smallSquareRoomBlueprint, RoomType.Normal, 0);
+        Room r1 = new Room(_smallSquareRoomBlueprint, 0);
 
         var aabbBefore = r1.GetBoundingBox();
 

--- a/Dungen/Dungen.csproj
+++ b/Dungen/Dungen.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
-    <Version>1.0.15</Version>
+    <Version>1.0.16</Version>
     <RepositoryUrl>https://github.com/karatakos/dungen</RepositoryUrl>
   </PropertyGroup>
 

--- a/Dungen/DungenGenerator.cs
+++ b/Dungen/DungenGenerator.cs
@@ -55,7 +55,7 @@ public class DungenGenerator {
 
         // Cache config spaces for all room template combinations
         //
-        _csBuilder.Precompute(RoomTemplateFactory.GetAllTemplates());
+        _csBuilder.Precompute(RoomTemplateFactory.VendRoomTemplates(Graph));
 
          _initilized = true;
     }
@@ -184,9 +184,9 @@ public class DungenGenerator {
 
                 bestLayout.Rooms.Add(
                     chain.Vertices[0], 
-                    RoomTemplateFactory.VendRandomTemplate(
-                        chain.Vertices[0].Id, 
-                        chain.Vertices[0].Definition.Type));
+                    RoomTemplateFactory.VendRoom(
+                        chain.Vertices[0].Definition, 
+                        chain.Vertices[0].Id));
 
                 chainVerticesVisited++;
             }
@@ -217,7 +217,7 @@ public class DungenGenerator {
 
                 // Grab config space making sure to shuffle neighbours for additional randomness 
                 //
-                Room room = RoomTemplateFactory.VendRandomTemplate(vertex.Id, vertex.Definition.Type);
+                Room room = RoomTemplateFactory.VendRoom(vertex.Definition, vertex.Id);
                 if (!_csBuilder.TryFromRooms(neighbours.Shuffle(), room, out ConfigSpace cspace))
                     continue;
 
@@ -408,9 +408,9 @@ public class DungenGenerator {
         bool perturbShape = x >= 0.7f;
 
         if (perturbShape)
-            roomTemplate = RoomTemplateFactory.VendRandomTemplate(
-                vertex.Id, 
-                vertex.Definition.Type, 
+            roomTemplate = RoomTemplateFactory.VendRoom(
+                vertex.Definition, 
+                vertex.Id,
                 roomTemplate);
 
         if (!_csBuilder.TryFromRooms(

--- a/Dungen/Geometry/Room.cs
+++ b/Dungen/Geometry/Room.cs
@@ -2,18 +2,12 @@ namespace Dungen;
 
 public class Room : Polygon2d {
     public RoomBlueprint Blueprint;
-
-    public RoomType Type { get; set; }
-
     public int Number { get; set; } = -1;
-
     public Vector2F Position { get; set; } = new Vector2F(0, 0);
-
     public List<Door> Doors { get; set; }
 
     public Room(Room copy) : base(copy) {
         Number = copy.Number;
-        Type = copy.Type;
         Blueprint = copy.Blueprint;
         Doors = DeepCopyOfDoors(copy.Doors);
 
@@ -22,19 +16,17 @@ public class Room : Polygon2d {
 
     public Room(Room copy, List<Vector2F> newShape) : base(newShape) {
         Number = copy.Number;
-        Type = copy.Type;
         Blueprint = copy.Blueprint;
         Doors = DeepCopyOfDoors(copy.Doors);
 
         Position = copy.Position;
     }
 
-    public Room(RoomBlueprint blueprint, RoomType type = RoomType.Normal, int number = -1) : 
-        this (blueprint, new Vector2F(0, 0), type, number) {}
+    public Room(RoomBlueprint blueprint, int number = -1) : 
+        this (blueprint, new Vector2F(0, 0), number) {}
 
-    public Room(RoomBlueprint blueprint, Vector2F pos, RoomType type = RoomType.Normal, int id = -1) : base(blueprint.Points) {
+    public Room(RoomBlueprint blueprint, Vector2F pos, int id = -1) : base(blueprint.Points) {
         Number = id;
-        Type = type;
         Blueprint = blueprint;
         Position = pos;
         Doors = new List<Door>();

--- a/Dungen/Geometry/RoomTemplateFactory.cs
+++ b/Dungen/Geometry/RoomTemplateFactory.cs
@@ -1,64 +1,48 @@
 namespace Dungen;
 
 public class RoomTemplateFactory {
-    private static RoomTemplateFactory Instance { get; set; }
+    private RoomTemplateFactory() {}
 
-    private HashSet<Room> _templates;
-
-    private Dictionary<RoomType, List<Room>> _templatesByType;
-
-    private RoomTemplateFactory() {
-        _templates = new HashSet<Room>();
-        _templatesByType = new Dictionary<RoomType, List<Room>>();
-    }
-
-    public static void Register(RoomDefinition definition) {
-        if (Instance == null)
-            Instance = new RoomTemplateFactory();
-
-        foreach (RoomBlueprint blueprint in definition.Blueprints) {
-            Room tmp = new Room(blueprint, definition.Type);
-            if (!Instance._templatesByType.ContainsKey(definition.Type))
-                Instance._templatesByType.Add(definition.Type, new List<Room>());
-
-            if (!Instance._templates.Contains(tmp))
-                Instance._templates.Add(tmp);
-
-            if (!Instance._templatesByType[definition.Type].Contains(tmp))
-                Instance._templatesByType[definition.Type].Add(tmp);
-        }
-    }
-
-    public static Room VendRandomTemplate(int roomId, RoomType type, Room exclude = null) {
-        if (Instance == null || !Instance._templatesByType.TryGetValue(type, out List<Room> tmp))
-            throw new Exception("Room definition provided has not been registed for any vertex");
-
+    public static Room VendRoom(RoomDefinition definition, int roomId, Room exclude = null) {
         List<Room> rooms = new List<Room>();
-        if (exclude != null) {
-            foreach (Room r in tmp) 
-                rooms.Add(r);
-        }   
-        else
-            rooms = tmp;
+        foreach (RoomBlueprint blueprint in definition.Blueprints) {
+            var room = new Room(blueprint, roomId);
 
+            // BUG: Why the fuck is the class not doing this itself?
+            //
+            room.Position = room.GetCenter();
+
+            if (exclude != room)
+                rooms.Add(new Room(blueprint, roomId));
+        }
+        
+        // No special selection logic for the blueprint
+        //
         Random rnd = new Random();
         int index = rnd.Next(0, rooms.Count);
-        
-        // Associate the corresponding vertex ID in the graph and reset it's position
-        //
-        Room newRoom = new Room(rooms[index]); 
-        newRoom.Number = roomId;
-        newRoom.Position = newRoom.GetCenter();
 
-        return newRoom;
+        return rooms[index];
     }
 
-    public static Room[] GetAllTemplates() {
-        if (Instance == null)
-            throw new Exception("No templates have been initialized");
+    /* Helper method to spit out a room for each unique blueprint in a graph
+    *
+    *  Important: Not designed to call multiple times efficiently (no caching)
+    */
+    public static Room[] VendRoomTemplates(DungenGraph graph) {
+        var roomsHashmap = new HashSet<Room>();
+        var rooms = new List<Room>();
 
-        // TODO: Remove collection and replace with _templatesByType.Distinct() call
-        //
-        return Instance._templates.ToArray();
+        foreach (Vertex v in graph.Vertices) {
+            foreach (RoomBlueprint bp in v.Definition.Blueprints) {
+                var room = new Room(bp);
+
+                if (!roomsHashmap.Contains(room)) {
+                    roomsHashmap.Add(room);
+                    rooms.Add(room);
+                }   
+            }
+        }
+
+        return rooms.ToArray();
     }
 }

--- a/Dungen/Graph/DungenGraph.cs
+++ b/Dungen/Graph/DungenGraph.cs
@@ -15,8 +15,6 @@ public class DungenGraph : UndirectedAdjacencyListGraph<Vertex> {
     }
     
     public void AddRoom(int roomId, RoomDefinition definition) {
-        RoomTemplateFactory.Register(definition);
-
         this.AddVertex(new Vertex(roomId, definition));
     }
 


### PR DESCRIPTION
1. Removed room factory registration mechanism as it was optimisation for a problem that didn't exist and the code made no sense. 
2. Removed room definition types as it's completely irrelevant to this library at least at this point. Now we vend rooms directly from a definition's blueprints, which we always had access to from a Graph's vertex.